### PR TITLE
LPAL-499 Adds default encryption for sns topic

### DIFF
--- a/modules/account_region/sns.tf
+++ b/modules/account_region/sns.tf
@@ -1,6 +1,7 @@
 resource "aws_sns_topic" "config" {
-  name = var.config_name
-  tags = var.tags
+  name              = var.config_name
+  tags              = var.tags
+  kms_master_key_id = "alias/aws/sns"
 }
 
 resource "aws_sns_topic_policy" "config" {


### PR DESCRIPTION
Context: security hub is flagging the sns topic for config as a MEDIUM.

This PR adds standard kms encryption for the topic, which will remove that warning.